### PR TITLE
Output subsequent probabilities.

### DIFF
--- a/src/main/scala/org/monarchinitiative/boomer/Mapping.scala
+++ b/src/main/scala/org/monarchinitiative/boomer/Mapping.scala
@@ -77,14 +77,14 @@ object Mapping {
     res
   }
 
-  def groupResultsByEquivalenceClique(results: List[ResolvedUncertainties],
+  def groupResultsByEquivalenceClique(results: List[List[ResolvedUncertainties]],
                                       equivalenceCliques: Map[AtomicConcept, Set[AtomicConcept]],
-                                      mappings: Set[Mapping]): Map[Set[AtomicConcept], ResolvedUncertainties] = {
+                                      mappings: Set[Mapping]): Map[Set[AtomicConcept], List[ResolvedUncertainties]] = {
     val mappingsByUncertainty = mappings.map(mapping => mapping.uncertainty -> mapping).toMap
     results
       .map { result =>
         val cliqueOption = for {
-          (uncertainty, _) <- result.headOption
+          (uncertainty, _) <- result.head.uncertainties.headOption
           mapping <- mappingsByUncertainty.get(uncertainty)
           clique <- equivalenceCliques.get(mapping.left)
         } yield clique

--- a/src/test/scala/org/monarchinitiative/boomer/TestUnresolvable.scala
+++ b/src/test/scala/org/monarchinitiative/boomer/TestUnresolvable.scala
@@ -15,7 +15,7 @@ object TestUnresolvable extends DefaultRunnableSpec {
         axioms <- loadTestAxiomsFromFile("unresolvable-mappings-test1.ofn")
         delegates = Map(NamespaceChecker.DelegateKey -> NamespaceChecker(Set.empty, Nil)) //TODO handle error if this is not provided
         whelk = Reasoner.assert(axioms, delegates)
-        result <- Boom.evaluate(axioms, uncertainties1, Set.empty, whelk, 10, 1, false)
+        result <- Boom.evaluateGreedily(uncertainties1, whelk, 10, 1)
       } yield result
       assertM(resultIO.flip)(equalTo(UnresolvableUncertainties))
     },
@@ -24,7 +24,7 @@ object TestUnresolvable extends DefaultRunnableSpec {
         axioms <- loadTestAxiomsFromFile("unresolvable-mappings-test2.ofn")
         delegates = Map(NamespaceChecker.DelegateKey -> NamespaceChecker(Set.empty, Nil))
         whelk = Reasoner.assert(axioms, delegates)
-        result <- Boom.evaluate(axioms, uncertainties2, Set.empty, whelk, 10, 1, false)
+        result <- Boom.evaluateGreedily(uncertainties2, whelk, 10, 1)
       } yield assert(result)(isNonEmpty)
     }
   )


### PR DESCRIPTION
For #153. Updated Markdown output:

## [Acrylonitrile](http://purl.obolibrary.org/obo/NCIT_C28130) [ECTO:0001601](http://purl.obolibrary.org/obo/ECTO_0001601) [Wikidata:Q21167650](http://www.wikidata.org/entity/Q21167650)
Method: exhaustive search
Score: -0.48755678849332484
Subsequent scores (max 10): -6.153983476605757, -6.153983476605757, -6.153983476605757, -6.153983476605757, -6.153983476605757, -6.153983476605757, -6.153983476605757, -6.153983476605757, -6.153983476605757, -8.987196820661973

- [ECTO:0001601](http://purl.obolibrary.org/obo/ECTO_0001601) EquivalentTo [Wikidata:Q21167650](http://www.wikidata.org/entity/Q21167650)	(most probable)	0.85
- [Acrylonitrile](http://purl.obolibrary.org/obo/NCIT_C28130) EquivalentTo [Wikidata:Q21167650](http://www.wikidata.org/entity/Q21167650)	(most probable)	0.85
- [ECTO:0001601](http://purl.obolibrary.org/obo/ECTO_0001601) EquivalentTo [Acrylonitrile](http://purl.obolibrary.org/obo/NCIT_C28130)	(most probable)	0.85