### PR TITLE
Adding reporting of confidence and estimation of corrected posterior probability

### DIFF
--- a/src/main/scala/org/monarchinitiative/boomer/Main.scala
+++ b/src/main/scala/org/monarchinitiative/boomer/Main.scala
@@ -237,9 +237,17 @@ object Main extends ZCaseApp[Options] {
               .sorted
               .mkString(" ")
         val subsequentScores = selections.tail.take(subsequentNum).map(Boom.jointProbability).map(_.toString).mkString(", ")
+        val score = Boom.jointProbability(bestSelections)
+        val confidence =
+          if (selections.length >= 2) {
+            Math.exp(score) / (Math.exp(Boom.jointProbability(selections(1))) + Math.exp(score))
+          } else
+            1.0
+        val estimatedPosterior =
+            Math.exp(score) / selections.map(Boom.jointProbability).map(Math.exp).sum
         effectBlocking(
           writer.println(
-            s"## $cliqueName\nMethod: ${bestSelections.method}\nScore: ${Boom.jointProbability(bestSelections)}\nSubsequent scores (max $subsequentNum): $subsequentScores\n"
+            s"## $cliqueName\nMethod: ${bestSelections.method}\nScore: ${score}\nEstimated probability: ${estimatedPosterior}\nConfidence: ${confidence}\nSubsequent scores (max $subsequentNum): $subsequentScores\n"
           )
         ) *>
           ZIO.foreach_(bestSelections.uncertainties) { case (unc, (selection, best)) =>


### PR DESCRIPTION
Adds two more metrics, see #153 for context

- confidence: `Pr(best) / ( Pr(best) + Pr(nextBest))`
- estimated posterior probability: `Pr(best) / Sum[Pr(allKnownSolutions)]`

the confidence is a very useful first measure of how much we trust it. If there is an alternate solution with a similar probability we trust less.

the estimated posterior probability is different from the exp of the current score in that it takes into account the fact that unsatisfiable states have zero probability. This is most reliable if exhaustive search is done. For greedy it will over-estimate. This is fine as it's more of a guide on best possible scenario.

@balhoff I won't be offended if you rewrite to be more scala-esque

before merging, I just wanted to check `selections` is not some kind of lazy list - I am iterating over them all to get all probabilities. If this causes performance issues we could do an ad-hoc first N or just omit this.

there may be a smarter way to do the calculation staying in log space, going into p space introduces the possibility of underflow errors but these are estimates in any case